### PR TITLE
Support `.yml` YAML files

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ function addToHashMap(hash, obj, locale) {
 
 function objFromFile(filePath) {
   const ext = path.extname(filePath);
-  if (ext === ".yaml") {
+  if ([".yaml", ".yml"].includes(ext)) {
     return yaml.safeLoad(fs.readFileSync(filePath, "utf8"));
   } else if (ext === ".json") {
     return JSON.parse(fs.readFileSync(filePath, "utf8"));


### PR DESCRIPTION
While the "official" file extension for YAML is `.yaml` many resources online still use `.yml` as the file extension of YAML. The application I work in has been using `.yml` for years and we'd love to use this addon without having to rename the files.

Ember Intl itself supports both the `.yaml` and `.yml` extension.